### PR TITLE
Remove cross-connection session state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,18 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,20 +152,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
-name = "blake3"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures",
-]
 
 [[package]]
 name = "block-buffer"
@@ -326,12 +300,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -483,7 +451,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",
- "blake3",
  "clap",
  "dirs",
  "futures",

--- a/epoxy/Cargo.toml
+++ b/epoxy/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
-blake3 = "1.8"
 clap = { version = "4.5", features = ["derive", "string"] }
 dirs = "6.0"
 futures = "0.3"

--- a/epoxy/src/proto/requests.rs
+++ b/epoxy/src/proto/requests.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde_with::base64::{Base64, Standard};
 use serde_with::formats::Unpadded;
-use serde_with::serde_as;
+use serde_with::{DisplayFromStr, serde_as};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Deserialize)]
@@ -12,6 +12,7 @@ pub enum Request {
     #[serde(rename = "GET_PROVIDERS")]
     GetProviders,
     #[serde(rename = "GET_TERMINALS")]
+    #[allow(unused)]
     GetTerminals(GetTerminals),
     #[serde(rename = "GET_CERTIFICATES")]
     GetCertificates(GetCertificates),
@@ -34,13 +35,13 @@ pub struct GetInfo {
 #[serde(rename_all = "camelCase")]
 pub struct GetTerminals {
     #[allow(unused)]
-    pub provider_id: i32,
+    pub provider_id: usize,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetCertificates {
-    pub terminal_id: i32,
+    pub terminal_id: usize,
     #[allow(unused)]
     #[serde(skip)]
     pub pin: String,
@@ -58,10 +59,12 @@ pub struct GetSignedXml {
     pub xml: Vec<u8>,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Certificate {
-    pub alias: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub alias: usize,
     #[allow(unused)]
     #[serde(skip)]
     pub name: String,

--- a/epoxy/src/proto/responses.rs
+++ b/epoxy/src/proto/responses.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_repr::Serialize_repr;
 use serde_with::base64::{Base64, Standard};
 use serde_with::formats::Unpadded;
-use serde_with::serde_as;
+use serde_with::{DisplayFromStr, serde_as};
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "operation")]
@@ -41,7 +41,7 @@ impl<T, S> ResultResponse<T, S> {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SuccessResponse<T> {
-    status: i32,
+    status: u32,
     payload: T,
 }
 
@@ -68,7 +68,7 @@ impl<S> ErrorResponse<S> {
 pub struct OnOpenEvent {
     pub app_name: String,
     pub app_version: String,
-    pub app_build: i32,
+    pub app_build: u32,
     pub os_name: String,
     pub os_version: String,
     pub os_arch: String,
@@ -91,15 +91,15 @@ impl OnOpenEvent {
 #[serde(rename_all = "camelCase")]
 pub struct GetInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider_id: Option<i32>,
+    pub provider_id: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminal_id: Option<i32>,
+    pub terminal_id: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate_id: Option<String>,
 }
 
 #[derive(Debug, Serialize_repr)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum GetInfoErrorCode {
     GenericError = 1100,
 }
@@ -113,12 +113,12 @@ pub struct GetProviders {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Provider {
-    pub id: i32,
+    pub id: usize,
     pub name: String,
 }
 
 #[derive(Debug, Serialize_repr)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum GetProvidersErrorCode {
     GenericError = 1200,
 }
@@ -132,12 +132,12 @@ pub struct GetTerminals {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Terminal {
-    pub id: i32,
+    pub id: usize,
     pub name: String,
 }
 
 #[derive(Debug, Serialize_repr)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum GetTerminalsErrorCode {
     GenericError = 1300,
 }
@@ -148,15 +148,17 @@ pub struct GetCertificates {
     pub certificates: Vec<Certificate>,
 }
 
+#[serde_as]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Certificate {
-    pub alias: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub alias: usize,
     pub name: String,
 }
 
 #[derive(Debug, Serialize_repr)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum GetCertificatesErrorCode {
     GenericError = 1400,
 }
@@ -170,7 +172,7 @@ pub struct GetSignedXml {
 }
 
 #[derive(Debug, Serialize_repr)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum GetSignedXmlErrorCode {
     GenericError = 1500,
 }


### PR DESCRIPTION
The client doesn't make use of this, it's better to simplify the code by removing the session hashmap entirely.